### PR TITLE
setup guard duty master

### DIFF
--- a/config/prod/GuardDutyMaster.yaml
+++ b/config/prod/GuardDutyMaster.yaml
@@ -1,0 +1,8 @@
+template_path: templates/GuardDutyMaster.yaml
+stack_name: guardduty-master
+dependencies:
+  - essentials
+parameters:
+  BridgeProdAwsAccountId: "{{ environment_variable.BridgeProdAwsAccountId }}"
+  SynapseProdAwsAccountId: "{{ environment_variable.SynapseProdAwsAccountId }}"
+  OperatorEmail: {{ environment_variable.OperatorEmail }}

--- a/templates/GuardDutyMaster.yaml
+++ b/templates/GuardDutyMaster.yaml
@@ -1,0 +1,62 @@
+# Template ref: https://theithollow.com/2018/04/02/protect-your-aws-accounts-with-guardduty/
+AWSTemplateFormatVersion: 2010-09-09
+Description: GuardDuty master with CloudWatch Event Rule and SNS Topic
+Parameters:
+  BridgeProdAwsAccountId:
+    Type: String
+    NoEcho: true
+  SynapseProdAwsAccountId:
+    Type: String
+    NoEcho: true
+  OperatorEmail:
+    Type: String
+    Description: Email for Guard duty findings
+Resources:
+  GDDetector:
+    Type: 'AWS::GuardDuty::Detector'
+    Properties:
+      Enable: true
+  GDSNSTopic:
+    Type: 'AWS::SNS::Topic'
+    Properties:
+      DisplayName: !Join
+        - '-'
+        - - GuardDuty
+          - SNSTopic
+      TopicName: !Join
+        - '-'
+        - - GuardDuty
+          - SNSTopic
+  GDCWEvent:
+    Type: 'AWS::Events::Rule'
+    Properties:
+      Description: GuardDuty Event Rule
+      EventPattern:
+        source:
+          - aws.guardduty
+        detail-type:
+          - GuardDuty Finding
+      State: ENABLED
+      Targets:
+        - Arn: !Ref GDSNSTopic
+          Id: TargetGuardDutySNSTopic
+  GuardDutySubscription:
+    Type: 'AWS::SNS::Subscription'
+    Properties:
+      Endpoint: !Ref OperatorEmail
+      Protocol: email
+      TopicArn: !Ref GDSNSTopic
+  GDBridgeProdMember:
+    Type: 'AWS::GuardDuty::Member'
+    Properties:
+      DetectorId: !Ref GDDetector
+      Email: bridgeit@sagebase.org
+      MemberId: !Ref BridgeProdAwsAccountId
+      Status: Invited
+  GDSynapseProdMember:
+    Type: 'AWS::GuardDuty::Member'
+    Properties:
+      DetectorId: !Ref GDDetector
+      Email: platform@sagebase.org
+      MemberId: !Ref SynapseProdAwsAccountId
+      Status: Invited


### PR DESCRIPTION
setup guard duty in master/member configuration[1]. This
will setup the master.  The template to setup members
will be placed in Sage-Bionetworks/aws-infra repo.

[1] https://aws.amazon.com/blogs/security/how-to-manage-amazon-guardduty-security-findings-across-multiple-accounts/