### PR TITLE
remove policy to beanstalk buckets

### DIFF
--- a/templates/accounts.yaml
+++ b/templates/accounts.yaml
@@ -143,19 +143,6 @@ Resources:
             Resource:
               - !Join
                 - ''
-                - - 'arn:aws:s3:::elasticbeanstalk-'
-                  - !Ref AWS::Region
-                  - '-'
-                  - !Ref AWS::AccountId
-                  - '/*'
-              - !Join
-                - ''
-                - - 'arn:aws:s3:::elasticbeanstalk-'
-                  - !Ref AWS::Region
-                  - '-'
-                  - !Ref AWS::AccountId
-              - !Join
-                - ''
                 - - 'arn:aws:s3:::'
                   - !ImportValue us-east-1-essentials-CloudtrailBucket
                   - '/*'


### PR DESCRIPTION
We do not plan to run any beanstalk apps in logcentral account so
there is no need for our external logging service to have access
to a beanstalk bucket.